### PR TITLE
fix: decode double-encoded HTML entities in code blocks

### DIFF
--- a/lib/text_parser.dart
+++ b/lib/text_parser.dart
@@ -6,6 +6,7 @@ import 'package:csslib/visitor.dart' as css;
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_highlight/themes/monokai.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:html_unescape/html_unescape.dart';
 import 'package:linkfy_text/linkfy_text.dart';
 
 import 'color_extension.dart';
@@ -840,7 +841,8 @@ class TextParser extends StatelessWidget {
                 .firstWhere((s) => s?.startsWith('language-') ?? false,
                     orElse: () => null)
                 ?.substring('language-'.length);
-            final code = elementNodes.first.text ?? '';
+            final rawCode = elementNodes.first.text ?? '';
+            final code = HtmlUnescape().convert(rawCode);
             return CodeBlock(
               code,
               language: language,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -172,6 +172,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.4"
+  html_unescape:
+    dependency: "direct main"
+    description:
+      name: html_unescape
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: transitive
     description:
@@ -200,26 +208,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   linkfy_text:
     dependency: "direct main"
     description:
@@ -233,26 +241,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -454,10 +462,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   tuple:
     dependency: transitive
     description:
@@ -510,10 +518,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -547,5 +555,5 @@ packages:
     source: hosted
     version: "6.3.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.19.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   highlight: ^0.7.0
   crypto: ^3.0.1
   csslib: ^0.17.1
+  html_unescape: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Fix display of `<>` and other HTML entities in code blocks that appear as `&lt;&gt;` instead of `<>`
- The Matrix SDK pre-escapes `<>` before markdown parsing, but `markdownToHtml()` also escapes inside code blocks → double encoding
- Apply `HtmlUnescape` to code block text content extracted from the DOM before passing to `CodeBlock`

## Context
- Issue: https://github.com/linagora/twake-on-matrix/issues/3089
- Root cause is in the Matrix Dart SDK (`markdown()` function, PR famedly/matrix-dart-sdk#2178), but this render-side fix ensures correct display of both new and historical messages

## Test plan
- [ ] Send a message with `<>` in a fenced code block → should display `<>` not `&lt;&gt;`
- [ ] Send inline code with generics: `` `List<String>` `` → should display correctly
- [ ] Send code block with intentional `&lt;` → should display `&lt;` (no over-decoding, `.text` already decoded it)