### PR TITLE
fix: preserve single blank line between paragraphs

### DIFF
--- a/lib/text_parser.dart
+++ b/lib/text_parser.dart
@@ -736,7 +736,12 @@ class TextParser extends StatelessWidget {
     var currentChildren = <InlineSpan>[];
     final widgets = <Widget>[];
     var lastNodeBlock = false;
-    final cleanup = (bool thisNodeBlock, bool lastElement) {
+    // Tag of the last block element added, so paragraph-to-paragraph
+    // transitions can use a full blank-line gap (WYSIWYG) while other
+    // block transitions keep the compact 4px spacing.
+    String? lastBlockTag;
+    final fontSize = parseContext.textStyle.fontSize ?? 14.0;
+    final cleanup = (bool thisNodeBlock, bool lastElement, [double spacing = 4]) {
       if (currentChildren.isNotEmpty) {
         widgets.add(CleanRichText(
           _optimizeTextspan(TextSpan(children: currentChildren)),
@@ -756,7 +761,7 @@ class TextParser extends StatelessWidget {
       if ((thisNodeBlock || lastNodeBlock) &&
           !lastElement &&
           widgets.isNotEmpty) {
-        widgets.add(SizedBox(height: 4));
+        widgets.add(SizedBox(height: spacing));
       }
     };
     for (final node in nodes) {
@@ -767,14 +772,19 @@ class TextParser extends StatelessWidget {
         continue;
       }
       final widget = _parseNode(context, parseContext, node);
-      final thisNodeBlock = SUPPORTED_BLOCK_ELEMENTS
-          .contains(node is dom.Element ? node.localName?.toLowerCase() : null);
+      final thisTag =
+          node is dom.Element ? node.localName?.toLowerCase() : null;
+      final thisNodeBlock = SUPPORTED_BLOCK_ELEMENTS.contains(thisTag);
       if (widget is CleanRichText && !lastNodeBlock && !thisNodeBlock) {
         currentChildren.add(widget.child);
       } else {
-        cleanup(thisNodeBlock, false);
+        // A blank line typed by the user becomes two <p> paragraphs; give
+        // those a full line-height gap so the blank line stays visible.
+        final paragraphGap = thisTag == 'p' && lastBlockTag == 'p';
+        cleanup(thisNodeBlock, false, paragraphGap ? fontSize : 4.0);
         widgets.add(widget);
       }
+      if (thisNodeBlock) lastBlockTag = thisTag;
       lastNodeBlock = thisNodeBlock;
     }
     cleanup(lastNodeBlock, true);


### PR DESCRIPTION
## Problem

A blank line typed in the composer (`\n\n`) is converted by the markdown layer into two `<p>` paragraphs. The renderer only inserted a **4px** `SizedBox` between block siblings, far smaller than a line height, so the blank line visually collapsed into a plain line break. Users have to press Enter twice to get one visible blank line.

## Fix

In `_parseChildNodes`, use a full line-height gap (`fontSize`) between consecutive `<p>` paragraphs, keeping the compact 4px spacing for other block transitions (lists, headings, quotes) — no regression.

Fixes both sent and received multi-paragraph messages.

## Test

Verified in twake-on-matrix (web): a single blank line now stays visible.

<img width="1012" height="720" alt="image" src="https://github.com/user-attachments/assets/79ae0d65-e055-4c86-9bda-8333e3cbc7c2" />
<img width="992" height="318" alt="image" src="https://github.com/user-attachments/assets/95266e1b-85dd-4101-bd26-9492a775889f" />
<img width="247" height="103" alt="image" src="https://github.com/user-attachments/assets/a449599d-aa37-4a6f-a956-307f35e10ca6" />
